### PR TITLE
chore(flake/precommit): `7ffbe4d2` -> `50bd447e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783875506,
-        "narHash": "sha256-Hx7uYdd6XyBohpAyIJwzjsJrUsY9ucOpzxoGMV+AYsI=",
+        "lastModified": 1784275620,
+        "narHash": "sha256-vk/LLBBfr2c25A0IpvSqGbzqDtybWUnxO4YsiSCeWeg=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "7ffbe4d244ef810e871ff616988753131c9595e8",
+        "rev": "50bd447e1d3206ea63716ef6c77ac0deba9f0276",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1783834461,
-        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
+        "lastModified": 1784265529,
+        "narHash": "sha256-ohQQiPOngux8ofsrSlloHCMDhRMvocXqJiG8uH45Q5k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
+        "rev": "068175006cfb69d5b541a140ed93e361488c9e53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`50bd447e`](https://github.com/fredsystems/pre-commit-checks/commit/50bd447e1d3206ea63716ef6c77ac0deba9f0276) | `` chore(flake/nixpkgs): e7a3ca80 -> 753cc8a3 ``      |
| [`1f9ef53d`](https://github.com/fredsystems/pre-commit-checks/commit/1f9ef53dcdced2019d6b8ccca22a3f9bb455b819) | `` chore(flake/rust-overlay): a286e5b9 -> 06817500 `` |