### PR TITLE
chore(flake/nixpkgs): `1559d3da` -> `148bab9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`8fb237ff`](https://github.com/NixOS/nixpkgs/commit/8fb237ffd2da92f4eb36ea950120cc2dd110c951) | `` python3Package.paho-mqtt: backport fix for flaky tests ``                                                      |
| [`a430a19c`](https://github.com/NixOS/nixpkgs/commit/a430a19c1b8e4ca4e8ac512d94a7453f04955d45) | `` fzf: 0.74.1 -> 0.74.2 ``                                                                                       |
| [`5e51996e`](https://github.com/NixOS/nixpkgs/commit/5e51996eaa2f8264c89f908a0d219ad11de3838d) | `` sshp: init at 1.1.4 ``                                                                                         |
| [`5f63e876`](https://github.com/NixOS/nixpkgs/commit/5f63e876759c2ff1fbfb05ffbc1f0a1dd9a24299) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.20 -> 2.1.21 ``                             |
| [`7a797c06`](https://github.com/NixOS/nixpkgs/commit/7a797c06f7cfa2f0fa7650ca4155aa841d683cfe) | `` home-assistant-custom-components.dreo: 1.10.6 -> 1.11.0 ``                                                     |
| [`68ba738c`](https://github.com/NixOS/nixpkgs/commit/68ba738c2c0a7fc7d1e16d281bb78bdb653da103) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.83.13 -> 1.83.18 ``                                      |
| [`1b6356bd`](https://github.com/NixOS/nixpkgs/commit/1b6356bd485dc98bb1101d8abef6e61c26290b24) | `` xtb: 6.7.1-unstable-2026-05-16 -> bleed-unstable-2026-07-13 ``                                                 |
| [`3800e942`](https://github.com/NixOS/nixpkgs/commit/3800e94280a6b0883f8e4909ab0d9c7c796cbde9) | `` home-assistant-custom-components.local_luftdaten: 2.4.0 -> 2.5.1 ``                                            |
| [`75d6ee11`](https://github.com/NixOS/nixpkgs/commit/75d6ee11aa12cc4304d5c6f994a171f412866b5f) | `` djlint: 1.36.4 -> 1.43.1 ``                                                                                    |
| [`a841c36e`](https://github.com/NixOS/nixpkgs/commit/a841c36e78ab2f03060d4386e9fd1577b720d6c4) | `` nixl: 1.3.1 -> 1.3.2 ``                                                                                        |
| [`f107d397`](https://github.com/NixOS/nixpkgs/commit/f107d397fd3d1c62b5ebce0be10ef618b4d8b4f8) | `` python3Packages.nixl: fix build ``                                                                             |
| [`f614e4bb`](https://github.com/NixOS/nixpkgs/commit/f614e4bb2d0cc1fdef44d57dd1f9db8a5d3f323b) | `` plezy: 2.10.0 -> 2.11.0 ``                                                                                     |
| [`fb8c6238`](https://github.com/NixOS/nixpkgs/commit/fb8c623817d5d989fe5b5ffdc08d90c9f26d356f) | `` python3Packages.databricks-sdk: 0.121.0 -> 0.122.0 ``                                                          |
| [`30e44f93`](https://github.com/NixOS/nixpkgs/commit/30e44f932fdde8f7e213eb9470d9f21a5651675d) | `` systemctl-tui: 0.7.0 -> 0.8.0 ``                                                                               |
| [`9bee9265`](https://github.com/NixOS/nixpkgs/commit/9bee9265dea67c6b6f762183044b1b70b5ab191a) | `` python3Packages.alphashape: cleanup ``                                                                         |
| [`0bab11e5`](https://github.com/NixOS/nixpkgs/commit/0bab11e5982fc2d79e0464198c7af87342bb5006) | `` python3Packages.sentence-transformers: 5.4.1 -> 5.6.1 ``                                                       |
| [`955ba528`](https://github.com/NixOS/nixpkgs/commit/955ba5281f998413510b6297e390b988fccbf1ea) | `` nextvi: 7.0 -> 7.1 ``                                                                                          |
| [`0529d56f`](https://github.com/NixOS/nixpkgs/commit/0529d56f015c0a8a1d0da8d252921b1c04872d2b) | `` python3Packages.dm-control: 1.0.43 -> 1.0.44 ``                                                                |
| [`cc551d3b`](https://github.com/NixOS/nixpkgs/commit/cc551d3bc5defdc1419e169016899bb50db52905) | `` mujoco: 3.10.0 -> 3.11.0 ``                                                                                    |
| [`f7aeafe1`](https://github.com/NixOS/nixpkgs/commit/f7aeafe1cf95b2da1c12b9b2818eb091aa1f8feb) | `` python3Packages.dependency-injector: add distutils ``                                                          |
| [`7065be04`](https://github.com/NixOS/nixpkgs/commit/7065be0403e58ad5d17a40207d5ca45ebdddddc8) | `` python3Packages.pygitguardian: migrate to finalAttrs ``                                                        |
| [`71d73d36`](https://github.com/NixOS/nixpkgs/commit/71d73d36be1429757ad123608e88f6df0f517d87) | `` python3Packages.pygitguardian: 1.32.0 -> 1.33.1 ``                                                             |
| [`48649b8d`](https://github.com/NixOS/nixpkgs/commit/48649b8d11243fd5b111b276624e06333d44e07f) | `` python3Packages.pyexploitdb: 0.3.36 -> 0.3.37 ``                                                               |
| [`1c8a84c8`](https://github.com/NixOS/nixpkgs/commit/1c8a84c8bde607b28d8402dc8bb8cecc606eba7d) | `` python3Packages.publicsuffixlist: 1.0.2.20260725 -> 1.0.2.20260726 ``                                          |
| [`1ba7251d`](https://github.com/NixOS/nixpkgs/commit/1ba7251d1bcfe739348aa3f137aa8b0cd0d6ce05) | `` terraform-providers.cloudscale-ch_cloudscale: 5.1.0 -> 5.1.1 ``                                                |
| [`6b930ca5`](https://github.com/NixOS/nixpkgs/commit/6b930ca5e07a7ddac0276026c7e8caf5d79bddab) | `` python3Packages.tencentcloud-sdk-python: 3.1.146 -> 3.1.147 ``                                                 |
| [`4621f213`](https://github.com/NixOS/nixpkgs/commit/4621f2134e0ae324726b614610ca8010e5d860a5) | `` python3Packages.temperusb: migrate to finalAttrs ``                                                            |
| [`30e4c6ce`](https://github.com/NixOS/nixpkgs/commit/30e4c6ce1ad7bd8f6630edcc88fc325133927aa0) | `` bind: disable tests on loongarch ``                                                                            |
| [`ce67f5ed`](https://github.com/NixOS/nixpkgs/commit/ce67f5edde75eacf3e704961edf0caf4f3b8b5a3) | `` terraform-providers.hetznercloud_hcloud: 1.66.1 -> 1.68.0 ``                                                   |
| [`756af177`](https://github.com/NixOS/nixpkgs/commit/756af1775cade54c8074faa3708fa3376ec293a7) | `` lux-cli: 0.39.1 -> 0.39.7 ``                                                                                   |
| [`3f0fdbd5`](https://github.com/NixOS/nixpkgs/commit/3f0fdbd52d93b672298ef370540945e218ddb6e2) | `` pocket-id: add esch to maintainers ``                                                                          |
| [`6ef6a030`](https://github.com/NixOS/nixpkgs/commit/6ef6a0303d1f9fb0f7c8894793affcc0bb7e8a1d) | `` pocket-id: 2.11.0 -> 2.12.0 ``                                                                                 |
| [`9bf6aadf`](https://github.com/NixOS/nixpkgs/commit/9bf6aadfffcf687321a535edd937295647eb2a51) | `` shelfmark: 1.3.4 -> 1.3.5 ``                                                                                   |
| [`d008262d`](https://github.com/NixOS/nixpkgs/commit/d008262dd12d14014e56bc518d4fa4fa762b54fe) | `` devin-cli: 3000.2.17 -> 3000.3.22 ``                                                                           |
| [`ed0a9719`](https://github.com/NixOS/nixpkgs/commit/ed0a9719660d1cffef0137a81f78c6097a3ba897) | `` python3Packages.cyscale: 0.5.0 -> 0.7.0 ``                                                                     |
| [`3385a8a5`](https://github.com/NixOS/nixpkgs/commit/3385a8a54a2a7a9aa17450426898043eb6a6198f) | `` deluge: use standard-pkg-resources instead of pinning setuptools ``                                            |
| [`798f8579`](https://github.com/NixOS/nixpkgs/commit/798f8579fb29d568d77ad9915fba07dff8c34836) | `` wappalyzergo: 0.2.90 -> 0.2.91 ``                                                                              |
| [`cc377d64`](https://github.com/NixOS/nixpkgs/commit/cc377d64baa2f059d7967defc70d270cd03c2daf) | `` terraform-providers.hashicorp_aws: 6.55.0 -> 6.57.1 ``                                                         |
| [`5fc1efc5`](https://github.com/NixOS/nixpkgs/commit/5fc1efc5bb3325379311e8448355138fe3c2626f) | `` terraform-providers.datadog_datadog: 4.15.0 -> 4.17.0 ``                                                       |
| [`ea3fd0a5`](https://github.com/NixOS/nixpkgs/commit/ea3fd0a5632ae81b0a4a871021b1475b07b4cdb1) | `` google-java-format: use `finalAttrs` instead of `rec` ``                                                       |
| [`725cdc8b`](https://github.com/NixOS/nixpkgs/commit/725cdc8bb4a22476904fa0666b2fdc24bb16067b) | `` colloid-gtk-theme: add myself as maintainer ``                                                                 |
| [`eee8e3f4`](https://github.com/NixOS/nixpkgs/commit/eee8e3f4570a84fe66caa433445de037dd2d2bb5) | `` expresslrs-configurator: 1.8.2 -> 1.8.3 ``                                                                     |
| [`f07095d7`](https://github.com/NixOS/nixpkgs/commit/f07095d73102a09ad6f9d4bc996b3baeabe17499) | `` dolt: 2.2.2 -> 2.2.3 ``                                                                                        |
| [`918222f2`](https://github.com/NixOS/nixpkgs/commit/918222f2c2ad23fdc96ddb0c83887edc54e7fd93) | `` nelm: 1.25.3 -> 1.27.0 ``                                                                                      |
| [`7924f494`](https://github.com/NixOS/nixpkgs/commit/7924f494248d5fa00969955719551a9c440d87f4) | `` php85: 8.5.8 -> 8.5.9 ``                                                                                       |
| [`f10c8926`](https://github.com/NixOS/nixpkgs/commit/f10c8926a735425a62069943773fe6d4c1211550) | `` androidenv.test-suite: 96adc7d16ae7f971 -> c9083822a6670d26 ``                                                 |
| [`db2b32cc`](https://github.com/NixOS/nixpkgs/commit/db2b32cce36d7ba44e9a307775d6601ef3e3a505) | `` qq: 2026-07-20 -> 2026-07-30 ``                                                                                |
| [`06a4125b`](https://github.com/NixOS/nixpkgs/commit/06a4125bce8ca2b61681e22c9b56610a1163c4fd) | `` cosmic-wallpapers: use compound license system ``                                                              |
| [`237d2c39`](https://github.com/NixOS/nixpkgs/commit/237d2c39bb2f675c66abd36435391857cbec4bff) | `` switchfin: 0.9.2 -> 0.9.3 ``                                                                                   |
| [`dfd5f86d`](https://github.com/NixOS/nixpkgs/commit/dfd5f86ddd92c6cc5f1b749cf485d87c646540ab) | `` context7-mcp: 3.2.4 -> 3.2.5 ``                                                                                |
| [`8f31c6d4`](https://github.com/NixOS/nixpkgs/commit/8f31c6d4dd9a4b9ba3b0237012f7d21c44e58d5e) | `` python3Packages.genai-prices: 0.0.71 -> 0.1.0 ``                                                               |
| [`c1deaa7e`](https://github.com/NixOS/nixpkgs/commit/c1deaa7e6ed46a47812fb7953cba1c72b28667e6) | `` betterleaks: 1.6.1 -> 1.7.2 ``                                                                                 |
| [`7dd0835d`](https://github.com/NixOS/nixpkgs/commit/7dd0835d801a13ce3881bb7727ab30193cc4300c) | `` olivetin-3k: 3000.17.3 -> 3000.18.1 ``                                                                         |
| [`7ed6b9d5`](https://github.com/NixOS/nixpkgs/commit/7ed6b9d5d439bea8ecf1bdea4f133ae957d446d0) | `` dioxus-cli: 0.7.9 -> 0.7.10 ``                                                                                 |
| [`08b063e9`](https://github.com/NixOS/nixpkgs/commit/08b063e91c1248292f5b5aa2d1b88ca1f73664ca) | `` vorta: add passthru.updateScript ``                                                                            |
| [`deedb363`](https://github.com/NixOS/nixpkgs/commit/deedb363b39d425727c9257edc1b12edd329276c) | `` vorta: add stephsi to vorta package maintainers ``                                                             |
| [`d5e42ac0`](https://github.com/NixOS/nixpkgs/commit/d5e42ac0c282f3a55a603d115d7f2bba54235e98) | `` vorta: 0.11.0 -> 0.11.5 ``                                                                                     |
| [`6a2ec38a`](https://github.com/NixOS/nixpkgs/commit/6a2ec38afa8c8c532ae034d026f0806663a9c2b5) | `` colloid-gtk-theme: remove gtk-2 ``                                                                             |
| [`45235474`](https://github.com/NixOS/nixpkgs/commit/4523547408d91845bb484a513c1769de1d407520) | `` blockbench: 5.1.5 -> 5.1.6 ``                                                                                  |
| [`026f3be1`](https://github.com/NixOS/nixpkgs/commit/026f3be16b1e43aa6b34ede82efff853a2ff0cd7) | `` Revert "colloid-gtk-theme: remove" ``                                                                          |
| [`4154468a`](https://github.com/NixOS/nixpkgs/commit/4154468a0e0fa26d0bdf88f266fd8d1bc9e72a3d) | `` rattler-build: 0.70.0 -> 0.72.0 ``                                                                             |
| [`01e6b207`](https://github.com/NixOS/nixpkgs/commit/01e6b20722599fa01219db9744ee732a72ff548d) | `` signal-desktop: 8.18.0 -> 8.21.0 ``                                                                            |
| [`ada89018`](https://github.com/NixOS/nixpkgs/commit/ada89018abd6eec9b7c459412fc7d20e4baa1822) | `` home-assistant-custom-lovelace-modules.mushroom: 5.2.0 -> 5.2.1 ``                                             |
| [`34eacfb3`](https://github.com/NixOS/nixpkgs/commit/34eacfb336f52233318ea016b91f3a46c841dce3) | `` spruce: 1.35.13 -> 1.35.14 ``                                                                                  |
| [`0eab1732`](https://github.com/NixOS/nixpkgs/commit/0eab17324f5a2b1a9d891c1a5460f25b3e497d10) | `` terraform-providers.go-gitea_gitea: 0.7.0 -> 0.8.1 ``                                                          |
| [`4887b0d9`](https://github.com/NixOS/nixpkgs/commit/4887b0d99ee65f6729717cf03763ca2cec2c781f) | `` radicle-httpd: 0.26.0 -> 0.27.0 ``                                                                             |
| [`da1cbfb3`](https://github.com/NixOS/nixpkgs/commit/da1cbfb3861d192eeef075aa8d121991d2f37f5d) | `` stirling-pdf: 2.10.1 -> 2.14.2 ``                                                                              |
| [`e73df5d0`](https://github.com/NixOS/nixpkgs/commit/e73df5d097385ac87bb4f4c4da4a785e47b4a4c4) | `` python3Packages.otcextensions: 0.34.3 -> 0.34.4 ``                                                             |
| [`d669afca`](https://github.com/NixOS/nixpkgs/commit/d669afcaabd2106afd0949605499fa91255f4831) | `` python3Packages.otcextensions: rename from python3Packages.python-otcextensions ``                             |
| [`7fa0e909`](https://github.com/NixOS/nixpkgs/commit/7fa0e9097318357459c49a00864dbcca2c257ef4) | `` keepassxc: fix typo chromium native messaging ``                                                               |
| [`d359b87f`](https://github.com/NixOS/nixpkgs/commit/d359b87f406ce467635d56bba2d5f415979d5bf0) | `` terramate: 0.17.1 -> 0.17.2 ``                                                                                 |
| [`efabce55`](https://github.com/NixOS/nixpkgs/commit/efabce55eaeabb5476b80f2adc4870414353a5f7) | `` python3Packages.trezor: 0.20.0 -> 0.20.2 ``                                                                    |
| [`c69a70bb`](https://github.com/NixOS/nixpkgs/commit/c69a70bba8d9e18d7ba60990780577fcb03a00ba) | `` fiddler-everywhere: 7.8.0 -> 8.0.2 ``                                                                          |
| [`61847bbf`](https://github.com/NixOS/nixpkgs/commit/61847bbf3b5db147ff43e306e98ba52fec4bc53b) | `` wastebin: 3.7.0 -> 3.7.1 ``                                                                                    |
| [`336f08a7`](https://github.com/NixOS/nixpkgs/commit/336f08a733320c36277ccaceb2a19a8dbcec3314) | `` firefox-devedition-unwrapped: 153.0b13 -> 154.0b4 ``                                                           |
| [`8848c9d5`](https://github.com/NixOS/nixpkgs/commit/8848c9d5953f11f98f1d5c649948125036eccd9c) | `` wakatime-cli: 2.22.2 -> 2.23.0 ``                                                                              |
| [`20dfd7ba`](https://github.com/NixOS/nixpkgs/commit/20dfd7ba1556201d99fbd1e8c9eb0acdd1b0a64a) | `` various: replace copy_from_vm -> copy_from_machine ``                                                          |
| [`ec0552d1`](https://github.com/NixOS/nixpkgs/commit/ec0552d1d28e08c99f6fa5a5e42fd3bb740799fe) | `` ungoogled-chromium: 150.0.7871.186-1 -> 151.0.7922.71-1 ``                                                     |
| [`1198b95e`](https://github.com/NixOS/nixpkgs/commit/1198b95e25f900204a537547ea2eae5c653e86d5) | `` bombono: remove ``                                                                                             |
| [`f7f95d1b`](https://github.com/NixOS/nixpkgs/commit/f7f95d1b33264890ad57c53e0db9d179881b2534) | `` python3Packages.apex: fix build ``                                                                             |
| [`60be170a`](https://github.com/NixOS/nixpkgs/commit/60be170a3a6693186e1472d594188147c2fa7dc1) | `` nixos/tests/predictable-interface-names: Fix systemd reference ``                                              |
| [`4145ba7d`](https://github.com/NixOS/nixpkgs/commit/4145ba7dfde33bb693b7aee7e819e27517a235fa) | `` nixos/ifstate: Fix systemd package references ``                                                               |
| [`7a9d29cd`](https://github.com/NixOS/nixpkgs/commit/7a9d29cdd8c61b63d09788d9fd1861d84c0e3ef8) | `` servo: 0.3.0 -> 0.4.0 ``                                                                                       |
| [`4e89bd7c`](https://github.com/NixOS/nixpkgs/commit/4e89bd7ccc506587d00451aaee1ba8f5423b73a3) | `` libfaketime: fixup darwin build ``                                                                             |
| [`75568a32`](https://github.com/NixOS/nixpkgs/commit/75568a3200c13e4edac864516dba4257df311dda) | `` llvmPackages_22.compiler-rt: improve conditional precision ``                                                  |
| [`3efb1e22`](https://github.com/NixOS/nixpkgs/commit/3efb1e2289844e4f65e44d8c4cab576347d1399f) | `` python3Packages.django-bootstrap3: 26.1 -> 26.2 ``                                                             |
| [`2e6c5de8`](https://github.com/NixOS/nixpkgs/commit/2e6c5de839b9b3edee7b5cbfef23945d2ad3c69c) | `` home-assistant-custom-components.philips_airpurifier_coap: 0.36.2 -> 0.37 ``                                   |
| [`548acede`](https://github.com/NixOS/nixpkgs/commit/548acede9f4664fafa91dc58cb757c260163577d) | `` python3Packages.mlflow: 3.14.0 -> 3.15.0 ``                                                                    |
| [`22244cc6`](https://github.com/NixOS/nixpkgs/commit/22244cc6e9f3f8e747d38f5c94561eb5fd04cd79) | `` noctalia-greeter: add samiser to maintainers ``                                                                |
| [`34a3b0ee`](https://github.com/NixOS/nixpkgs/commit/34a3b0ee28a97b49a22ca26be0c3b5585a9433d7) | `` noctalia-greeter: 1.0.0 -> 1.1.0 ``                                                                            |
| [`d5fd7205`](https://github.com/NixOS/nixpkgs/commit/d5fd7205da4846340147da9a6be51b5c2fb46d17) | `` stalwart-proxy: 1.0.0 -> 1.0.1 ``                                                                              |
| [`278438ff`](https://github.com/NixOS/nixpkgs/commit/278438ff649b0976f8d06c5a15720fd024b4b9f8) | `` python3Packages.matscipy: fix build ``                                                                         |
| [`1f106a7b`](https://github.com/NixOS/nixpkgs/commit/1f106a7bf22417bb7cf1c9834700e45e9526fe43) | `` rainfrog: 0.3.20 -> 0.4.2 ``                                                                                   |
| [`296675a1`](https://github.com/NixOS/nixpkgs/commit/296675a1f0d0edee945e9e8b098a1c4b360962cb) | `` linuxPackages.amneziawg: 1.0.20260725 -> 3.0.20260731-02 ``                                                    |
| [`2beb74cc`](https://github.com/NixOS/nixpkgs/commit/2beb74cc5511da1be873b7947e100493d3aa8190) | `` postgrest: 14.15 -> 14.16 ``                                                                                   |
| [`fb431ae5`](https://github.com/NixOS/nixpkgs/commit/fb431ae5890a27496c47c3ee754d3052abadf0bc) | `` amneziawg-tools: 1.0.20260618-2 -> 3.0.20260730 ``                                                             |
| [`05eae33c`](https://github.com/NixOS/nixpkgs/commit/05eae33c1e84761a699c5286e7cf2a801882b383) | `` amneziawg-go: 3.0.1 -> 3.0.2 ``                                                                                |
| [`2c8dc84d`](https://github.com/NixOS/nixpkgs/commit/2c8dc84da3cb33968412638cc70e1dfd75dd0b5d) | `` zapret2: 1.0.3 -> 1.0.4 ``                                                                                     |
| [`caf070fb`](https://github.com/NixOS/nixpkgs/commit/caf070fb8e1acb2a1f61e3d927b8b0fe4ddb14af) | `` hmcl: 3.16.2 -> 3.16.3 ``                                                                                      |
| [`0565f0ec`](https://github.com/NixOS/nixpkgs/commit/0565f0ece9a4dec3ad1ca85297c61bdc1c97d9b6) | `` Revert "nixos-build-vms: set pname and version" ``                                                             |
| [`02679254`](https://github.com/NixOS/nixpkgs/commit/02679254d1a1d2d5d663d32e6aca58457c80471a) | `` Revert "nixos-enter: set pname and version" ``                                                                 |
| [`59474eab`](https://github.com/NixOS/nixpkgs/commit/59474eab88270640251cf4bc438d94317e002af6) | `` Revert "nixos-install: set pname and version" ``                                                               |
| [`56f920ec`](https://github.com/NixOS/nixpkgs/commit/56f920ecfe90484bb1013361cbe34e24d396736a) | `` gurk-rs: 0.9.3 -> 0.10.1 ``                                                                                    |
| [`e732b0cc`](https://github.com/NixOS/nixpkgs/commit/e732b0cc9e2a1fc762615eca2e3fcf08bd183fa1) | `` claude-agent-acp: 0.60.0 -> 0.64.0 ``                                                                          |
| [`9b1877f8`](https://github.com/NixOS/nixpkgs/commit/9b1877f8949d01b0f719665fef86b7dce5aef2a9) | `` python3Packages.{qscintilla and pyqt6-qscintilla}: update attribute name and pname to match python metadata `` |
| [`50906cfa`](https://github.com/NixOS/nixpkgs/commit/50906cfa769dc3b0069a11c2a777f4450ff55611) | `` victoriatraces: 0.9.4 -> 0.10.0 ``                                                                             |
| [`0e31e946`](https://github.com/NixOS/nixpkgs/commit/0e31e94636345b300f4ed730b195bf45a67b3698) | `` hunk: 0.17.3 -> 0.17.7 ``                                                                                      |
| [`13633612`](https://github.com/NixOS/nixpkgs/commit/13633612c7fbe164ae1e791ddd12a7e25d446b23) | `` breitbandmessung: 3.11.0 -> 3.12.0 ``                                                                          |
| [`a561f32c`](https://github.com/NixOS/nixpkgs/commit/a561f32c32461af55ad19f5843f46efc59ddfbf3) | `` harmonoid: 0.3.22 -> 0.3.32 ``                                                                                 |
| [`74e45f79`](https://github.com/NixOS/nixpkgs/commit/74e45f796b5bab322d4f93fe2a4a2dc7b7287ff1) | `` gh: 2.96.0 -> 2.97.0 ``                                                                                        |
| [`7cc93342`](https://github.com/NixOS/nixpkgs/commit/7cc9334215f88916c7eae2e1a6cbf9680f8c4bb4) | `` python3Packages.cryptoparser: fix changelog URL ``                                                             |
| [`e0f8bde5`](https://github.com/NixOS/nixpkgs/commit/e0f8bde5d743a0757dd6705fd06fc2bf84436354) | `` python3Packages.cryptolyzer: fix changelog URL ``                                                              |
| [`495c1ba8`](https://github.com/NixOS/nixpkgs/commit/495c1ba8aad3df20f524e2c7bf97f8592d84e431) | `` python3Packages.scancode-toolkit: fix homepage and changelog URL redirects ``                                  |
| [`f6f1cb3d`](https://github.com/NixOS/nixpkgs/commit/f6f1cb3d874f5e8adb233beaa67bc22a3c8ff520) | `` taler-merchant: fix homepage URL redirect ``                                                                   |
| [`0cbef9a5`](https://github.com/NixOS/nixpkgs/commit/0cbef9a542ae60901f1946d086604f9230cb2362) | `` taler-exchange: fix homepage URL redirect ``                                                                   |
| [`d8f87609`](https://github.com/NixOS/nixpkgs/commit/d8f876090b9e331b43260d9d63ca8ba7f5468d76) | `` gnunet: fix homepage URL redirect ``                                                                           |
| [`b0436cae`](https://github.com/NixOS/nixpkgs/commit/b0436caee07f94a2567842def7fad4ce11464bc8) | `` galene: fix changelog URL ``                                                                                   |
| [`e55b1ddf`](https://github.com/NixOS/nixpkgs/commit/e55b1ddf6b4b685949a6fc83fa08823ef28523c9) | `` goshs: fix CVE-2026-66063 and CVE-2026-66064 ``                                                                |
| [`3fad2800`](https://github.com/NixOS/nixpkgs/commit/3fad2800913e33fd51513ef7f50be8c189bbaf01) | `` dokieli: fix homepage URL redirect ``                                                                          |
| [`e185d05d`](https://github.com/NixOS/nixpkgs/commit/e185d05d174daad2276466436e956d44e0083768) | `` mise: 2026.7.10 -> 2026.7.17 ``                                                                                |
| [`11c0c896`](https://github.com/NixOS/nixpkgs/commit/11c0c89693eba12fbac8e4fddb3ae4a6328fdaa3) | `` go-hass-agent: 14.14.1 -> 14.15.0 ``                                                                           |
| [`f7c94932`](https://github.com/NixOS/nixpkgs/commit/f7c949323cf4e75a2810f93e7b9a9ac417ae6307) | `` python3Packages.blackjax: disable failing test ``                                                              |
| [`534556a8`](https://github.com/NixOS/nixpkgs/commit/534556a807ea66566a8e93dd4b839de600d9a776) | `` python3Packages.libcap_ng: fix passthru.tests.python ``                                                        |
| [`66908803`](https://github.com/NixOS/nixpkgs/commit/6690880374cda4b4d6afd17fe39db6f259744072) | `` vivaldi-ffmpeg-codecs: drop sarahec as maintainer ``                                                           |
| [`7410277e`](https://github.com/NixOS/nixpkgs/commit/7410277e3a18e3da04aed3122ee3254f5747dc8a) | `` vscode-extensions.charliermarsh.ruff: 2026.62.0 -> 2026.68.0 ``                                                |
| [`812b0129`](https://github.com/NixOS/nixpkgs/commit/812b012911ea6f155120b0e94ed90fc4a4474e02) | `` Revert "nixos-container: set pname and version" ``                                                             |
| [`e582e42f`](https://github.com/NixOS/nixpkgs/commit/e582e42fe8f9e4ad6e09cbe202bc958f06dfbd20) | `` portfolio: 0.86.0 -> 0.86.1 ``                                                                                 |
| [`885c272a`](https://github.com/NixOS/nixpkgs/commit/885c272a438aa50e187c7e355a16f082b893140f) | `` nixos/nushell: add module ``                                                                                   |
| [`197bd2c6`](https://github.com/NixOS/nixpkgs/commit/197bd2c6a07b3ea22df2019ecc954504148e0264) | `` nushell: add withPlugins using makeBinaryWrapper ``                                                            |
| [`81122854`](https://github.com/NixOS/nixpkgs/commit/81122854f223b0917b0a2a5db5ff336408d4b843) | `` nushell: mv plugins to by-name/nu/nushell/plugins ``                                                           |
| [`7025d66b`](https://github.com/NixOS/nixpkgs/commit/7025d66beced7d08b7c2146c37cae4989c5aa0b8) | `` maintainers: add brw ``                                                                                        |
| [`d5d0b6de`](https://github.com/NixOS/nixpkgs/commit/d5d0b6de06fd1b4bc7c59393a0c613a18b74b53f) | `` vivaldi-ffmpeg-codecs: 123075 -> 0-unstable-2026-05-18 ``                                                      |
| [`9e2c76f5`](https://github.com/NixOS/nixpkgs/commit/9e2c76f58a9da20a015ea596a508ea380f9a6d87) | `` atuin: 18.18.0 -> 18.18.1 ``                                                                                   |
| [`24965929`](https://github.com/NixOS/nixpkgs/commit/24965929c107a051ece4c53d62dc2a250b8c7cb7) | `` linux_xanmod: 6.18.40 -> 6.18.41 ``                                                                            |
| [`f5213a07`](https://github.com/NixOS/nixpkgs/commit/f5213a072c5f8cd59c30dbe8ae07e30db8841dad) | `` ijq: 1.3.0 -> 1.4.0 ``                                                                                         |
| [`f5e5e182`](https://github.com/NixOS/nixpkgs/commit/f5e5e18251f431da8f97760e130a54907bf27100) | `` python3Packages.ironcalc: fix eval ``                                                                          |
| [`3238a544`](https://github.com/NixOS/nixpkgs/commit/3238a54419f54c26c345d7590b35525a886cba23) | `` incus-lts: apply security fixes ``                                                                             |
| [`be7b2c38`](https://github.com/NixOS/nixpkgs/commit/be7b2c38fb77689bfe4a686c6be85d59b1fb717a) | `` src-cli: 7.5.0 -> 7.6.0 ``                                                                                     |
| [`df119cb4`](https://github.com/NixOS/nixpkgs/commit/df119cb4a2c0f941ae4b6f45c25764b00ce1aa65) | `` vacuum-tube: 1.8.1 -> 1.8.2 ``                                                                                 |
| [`1f821ff2`](https://github.com/NixOS/nixpkgs/commit/1f821ff29fad24ad7bb374def8448db798b38c47) | `` incus: 7.2.0 -> 7.3.0 ``                                                                                       |
| [`e88973b3`](https://github.com/NixOS/nixpkgs/commit/e88973b303a74654eae3160253cc70e280087a5a) | `` node-red: 5.0.2 -> 5.0.4 ``                                                                                    |
| [`911aab13`](https://github.com/NixOS/nixpkgs/commit/911aab1324e8b8f07f74a5b9e694e2dde6e0e638) | `` metasploit: use structuredAttrs and strictDeps ``                                                              |
| [`b9316beb`](https://github.com/NixOS/nixpkgs/commit/b9316beb4eeaaaa2c75b701669908432829f74e7) | `` metasploit: move to pkgs/by-name ``                                                                            |
| [`e3b5efb3`](https://github.com/NixOS/nixpkgs/commit/e3b5efb3a60251e4925def731ff867c77d642b21) | `` pam-honeycreds: 1.9 -> 2.0 ``                                                                                  |
| [`5a32fe97`](https://github.com/NixOS/nixpkgs/commit/5a32fe97bab44d753e734b126266fa34539e4235) | `` otpauth: 0.6.0 -> 0.6.1 ``                                                                                     |
| [`757dc48a`](https://github.com/NixOS/nixpkgs/commit/757dc48ad1643b478bb730b38d511afa60417717) | `` qq: 2026-05-28 -> 2026-07-20 ``                                                                                |
| [`45de3bfb`](https://github.com/NixOS/nixpkgs/commit/45de3bfb345d0ce4b39cf4e847630627d4609fbb) | `` libphonenumber: 9.0.35 -> 9.0.36 ``                                                                            |
| [`1057df16`](https://github.com/NixOS/nixpkgs/commit/1057df166e4b55cd5a41d060f98c31b02e120f21) | `` skopeo: 1.23.0 -> 1.24.0 ``                                                                                    |
| [`e8099140`](https://github.com/NixOS/nixpkgs/commit/e809914026b34cff1331aee1e397fc71073f643a) | `` python3Packages.standard-pkg-resources: init at 1.0.0 ``                                                       |
| [`712f4b84`](https://github.com/NixOS/nixpkgs/commit/712f4b849bd3a602925120f2b09eb2cf000795e9) | `` olympus-unwrapped: 26.07.12.04 -> 26.07.27.01 ``                                                               |
| [`4a9a07ed`](https://github.com/NixOS/nixpkgs/commit/4a9a07ed9100a8a65bcbad298894c2a1e29cc6eb) | `` buildah-unwrapped: 1.44.1 -> 1.45.0 ``                                                                         |
| [`5c331d4f`](https://github.com/NixOS/nixpkgs/commit/5c331d4f4c6454a0dd5e9ef66378c7c41b465bbb) | `` radicle-explorer: 0-unstable-2026-07-21 -> 0-unstable-2026-07-29 ``                                            |
| [`94ca3db4`](https://github.com/NixOS/nixpkgs/commit/94ca3db4a8623a2c2b7d4cb13a56140db9c16b77) | `` valeStyles.google: 0.6.3 -> 0.7.0 ``                                                                           |
| [`4d319739`](https://github.com/NixOS/nixpkgs/commit/4d31973921a9568e97ac38ad64987bcb8708841c) | `` oq: fix jq error on spec ``                                                                                    |
| [`8d914e4e`](https://github.com/NixOS/nixpkgs/commit/8d914e4eac0a18fff5402ac923892d82df8be89d) | `` folia-major: 0.6.1 -> 0.6.8 ``                                                                                 |
| [`15bdc7ca`](https://github.com/NixOS/nixpkgs/commit/15bdc7ca583a9c5e07ea1d59335b8dd5e3668e0b) | `` n-m3u8dl-re: fix meta.changelog ``                                                                             |
| [`d40e5f39`](https://github.com/NixOS/nixpkgs/commit/d40e5f39f6deafed624155ce1327c49a5fe0a0a6) | `` python3Packages.clarabel: set __structuredAttrs ``                                                             |
| [`dbccf7f7`](https://github.com/NixOS/nixpkgs/commit/dbccf7f7b5528ac3993b5314546482629e900d09) | `` maintainers: add zinzilulo ``                                                                                  |
| [`357e5452`](https://github.com/NixOS/nixpkgs/commit/357e545218d0950ee03a3c2767ef32d9cb1ead99) | `` linux_5_10: 5.10.261 -> 5.10.262 ``                                                                            |
| [`49aa3425`](https://github.com/NixOS/nixpkgs/commit/49aa3425d7a9180517638b410ae0d5468275b7d3) | `` linux_5_15: 5.15.212 -> 5.15.213 ``                                                                            |
| [`3c097f92`](https://github.com/NixOS/nixpkgs/commit/3c097f927691e1ad905b30906c69f8a7b95503c7) | `` eepers: add zinzilulo to maintainers ``                                                                        |
| [`12608ef2`](https://github.com/NixOS/nixpkgs/commit/12608ef2a45ec9488253ec9719d992996eb64b80) | `` linux_6_1: 6.1.178 -> 6.1.180 ``                                                                               |
| [`68ac597b`](https://github.com/NixOS/nixpkgs/commit/68ac597bdfda6236e64e24e45ee2c0729b95ed84) | `` linux_6_6: 6.6.145 -> 6.6.147 ``                                                                               |
| [`324efc5a`](https://github.com/NixOS/nixpkgs/commit/324efc5a8b33115f89dc8d3f699275fa56bd6206) | `` linux_6_12: 6.12.97 -> 6.12.100 ``                                                                             |
| [`8d75fd28`](https://github.com/NixOS/nixpkgs/commit/8d75fd2828f18d4f7c854c579aeecd6887750b3b) | `` linux_6_18: 6.18.40 -> 6.18.41 ``                                                                              |
| [`330e37ff`](https://github.com/NixOS/nixpkgs/commit/330e37ffc838b2ce5c4fe9e548f8acf21a5fc026) | `` eepers: fix build on non-linux platforms ``                                                                    |
| [`62dc8d8c`](https://github.com/NixOS/nixpkgs/commit/62dc8d8c5d295b8aee1e36e5fa9e1b7f3b7ad58d) | `` python3Packages.jax-tap: 0.3.0 -> 0.3.1 ``                                                                     |
| [`841966b4`](https://github.com/NixOS/nixpkgs/commit/841966b41f4bfecda7c5a8475c54a3eead2ce76a) | `` nixos/release-notes: mention monero hardening ``                                                               |
| [`70105636`](https://github.com/NixOS/nixpkgs/commit/7010563632fd7eef006c16d92c8ecc1d1bf83104) | `` monero: systemd service hardening configuration ``                                                             |
| [`4b4e791f`](https://github.com/NixOS/nixpkgs/commit/4b4e791fd5ae6f2dabd20e2f716b8919120e63c5) | `` python3Packages.garminconnect-aio: use finalAttrs ``                                                           |
| [`867212f2`](https://github.com/NixOS/nixpkgs/commit/867212f299331989826f8710e94e815b31a900c9) | `` python3Packages.garminconnect-aio: migrate to pyproject ``                                                     |
| [`5e4be6ae`](https://github.com/NixOS/nixpkgs/commit/5e4be6ae9905cd7885f0ba98c58f6892d4567dd6) | `` ruff: 0.16.0 -> 0.16.1 ``                                                                                      |
| [`c01ad2d3`](https://github.com/NixOS/nixpkgs/commit/c01ad2d366d16897fd6c58cf1f242d9edfb97f80) | `` multi-scrobbler: init at 0.15.0 ``                                                                             |
| [`bae3a975`](https://github.com/NixOS/nixpkgs/commit/bae3a975724e3ff1cb403ab310639ae2a82b3ad0) | `` n8n: 2.31.4 -> 2.32.6 ``                                                                                       |
| [`f2c2033a`](https://github.com/NixOS/nixpkgs/commit/f2c2033a345a7fdc52bb6115a6b479bce112339c) | `` ananicy-rules-cachyos: 0-unstable-2026-07-20 -> 0-unstable-2026-07-29 ``                                       |
| [`109d62ac`](https://github.com/NixOS/nixpkgs/commit/109d62ac1c47d5949e729a9172795cf742dcf74e) | `` netwatch: 0.26.1 -> 0.28.1 ``                                                                                  |
| [`36200af2`](https://github.com/NixOS/nixpkgs/commit/36200af2660741f62bb8b9e71079424bad21f6a7) | `` nrfutil: 8.1.1 -> 8.2.0 ``                                                                                     |
| [`9622c17b`](https://github.com/NixOS/nixpkgs/commit/9622c17b1825181296a8c21d28e569973b0fdd37) | `` nrfutil: guard nrfutil-completion as optional on all platforms ``                                              |
| [`353ee206`](https://github.com/NixOS/nixpkgs/commit/353ee206b5fd4046df6a574f165a4214ad387fc0) | `` nrfutil: expose allExtensions and withAllExtensions in passthru ``                                             |
| [`57e12d97`](https://github.com/NixOS/nixpkgs/commit/57e12d97050e8428cc69acf49d865b79751c4b8e) | `` nrfutil: add darwin support ``                                                                                 |
| [`178e5a0d`](https://github.com/NixOS/nixpkgs/commit/178e5a0da77c9317e06e23d5a1f97c1f9a27d3b9) | `` python3Packages.logurich: 0.9.2 -> 0.9.3 ``                                                                    |
| [`f9a959e6`](https://github.com/NixOS/nixpkgs/commit/f9a959e60a8280c38a99942af7e468e617925637) | `` pyhanko-cli: 0.4.0 -> 0.4.2 ``                                                                                 |
| [`2495de23`](https://github.com/NixOS/nixpkgs/commit/2495de235239a24251bfa89e0ddb5cd676082fb6) | `` python3Packages.django-postgres-extra: fix version in psqlextra/_version.py ``                                 |
| [`c32fa56f`](https://github.com/NixOS/nixpkgs/commit/c32fa56fd8d71cfd9f8816b0c04db2eb3530a179) | `` oniux: 0.10.0 -> 0.12.0 ``                                                                                     |
| [`be742101`](https://github.com/NixOS/nixpkgs/commit/be742101ac9ac42a2de6f974b2dc4fa532635acb) | `` matrix-continuwuity: 26.7.1 -> 26.7.2 ``                                                                       |
| [`8db7f570`](https://github.com/NixOS/nixpkgs/commit/8db7f5701d9078fc48d93bd44784bbac42ddd37b) | `` dgraph: 25.3.8 -> 25.4.0 ``                                                                                    |
| [`817cd8bf`](https://github.com/NixOS/nixpkgs/commit/817cd8bf46140c2e66af67552f1c10016c779c7f) | `` python3Packages.jupyterlab-git: 0.52.0 -> 0.54.0 ``                                                            |
| [`358bdbf5`](https://github.com/NixOS/nixpkgs/commit/358bdbf5fb9539323a9b8c9d33c36508976f51d5) | `` ejabberd: 26.04 -> 26.07 ``                                                                                    |
| [`05e605f3`](https://github.com/NixOS/nixpkgs/commit/05e605f35c65c4e411efc2362a06ada86eac34fc) | `` skills: 1.5.19 -> 1.5.21 ``                                                                                    |
| [`dd2a01cd`](https://github.com/NixOS/nixpkgs/commit/dd2a01cd5a223eb51de203f3426b2976e37a382e) | `` thunderbird-latest-unwrapped: 153.0 -> 153.0.1 ``                                                              |
| [`069e33c3`](https://github.com/NixOS/nixpkgs/commit/069e33c3b5308fd974d0d421e255b6ea388388d6) | `` gotestdox: 0.2.2 -> 0.2.3 ``                                                                                   |
| [`0412fc9c`](https://github.com/NixOS/nixpkgs/commit/0412fc9c68a8e2a7a75a66751f5d7eec7295a4e9) | `` dep-scan: 6.2.0 -> 6.3.0 ``                                                                                    |
| [`ef68a984`](https://github.com/NixOS/nixpkgs/commit/ef68a984cd250df8ae6e75b2fd33a336dc1e0852) | `` python3Packages.env-canada: 0.16.1 -> 0.18.0 ``                                                                |
| [`fb0b807f`](https://github.com/NixOS/nixpkgs/commit/fb0b807f9e5c738ab00183fbcb7c6fd7fce44249) | `` python3Packages.checkdmarc: 5.17.3 -> 5.17.4 ``                                                                |
| [`e2abd85f`](https://github.com/NixOS/nixpkgs/commit/e2abd85f69908d6c7f94afbbe6e2f1ab4a77a5af) | `` python3Packages.alibabacloud-vpc20160428: 7.1.3 -> 7.1.4 ``                                                    |
| [`d01befba`](https://github.com/NixOS/nixpkgs/commit/d01befbae9517b57babf6cab1202168279c78756) | `` gvm-libs: 23.9.0 -> 23.9.1 ``                                                                                  |
| [`e10aa451`](https://github.com/NixOS/nixpkgs/commit/e10aa4519353f582e00428ceb5095ade7884be5c) | `` python3Packages.aioshelly: 13.27.0 -> 13.29.0 ``                                                               |
| [`10fe9f12`](https://github.com/NixOS/nixpkgs/commit/10fe9f12a430770bfe53a1cdef2bd2115b36f7db) | `` thunderbird-esr-bin-unwrapped: 140.12.1esr -> 153.0.1esr ``                                                    |
| [`7c1d9528`](https://github.com/NixOS/nixpkgs/commit/7c1d9528ed3196c27424f89332d0794692834808) | `` music-assistant: 2.9.9 -> 2.9.10 ``                                                                            |
| [`b194d4a5`](https://github.com/NixOS/nixpkgs/commit/b194d4a52f35ea8ff925d58f7f08fea991ad343b) | `` pyrefly: 1.2.0-dev.2 -> 1.2.0-dev.3 ``                                                                         |
| [`6cfb8fb4`](https://github.com/NixOS/nixpkgs/commit/6cfb8fb448457a691dfce30a57a1ad1b6026eda2) | `` python3Packages.flax: 0.12.7 -> 0.12.8 ``                                                                      |
| [`bcb74302`](https://github.com/NixOS/nixpkgs/commit/bcb743026129c0d321d415c2f8253dd25149035f) | `` python3Packages.rlax: 0.1.8 -> 0.1.9 ``                                                                        |
| [`21b76d16`](https://github.com/NixOS/nixpkgs/commit/21b76d1626bd641813d752b6bdf06287324793fa) | `` python3Packages.distrax: 0.1.8 -> 0.1.9 ``                                                                     |
| [`127acb3a`](https://github.com/NixOS/nixpkgs/commit/127acb3a09a83f4a56691470493a51a53f6a5539) | `` python3Packages.dm-haiku: 0.0.16 -> 0.0.17 ``                                                                  |
| [`1170af56`](https://github.com/NixOS/nixpkgs/commit/1170af5687beb24759f8ca0d3dc8a97e00c09d2b) | `` tree-sitter: fix evaluation error ``                                                                           |
| [`2acf70a4`](https://github.com/NixOS/nixpkgs/commit/2acf70a4e29bf7327a7a0e1630cc562d8d3e6086) | `` binaryen: omit binaryen-unittests in non-cross too ``                                                          |
| [`f41e5ca5`](https://github.com/NixOS/nixpkgs/commit/f41e5ca56e8a864687780e038c51d762b6ed6ebe) | `` binaryen: make doCheck test more correct ``                                                                    |
| [`774a69f5`](https://github.com/NixOS/nixpkgs/commit/774a69f5381cfaa4109b5777590acf9d4f8f4ea2) | `` kitty: 0.48.1 -> 0.48.2 ``                                                                                     |
| [`fcf825ad`](https://github.com/NixOS/nixpkgs/commit/fcf825ad2e9e3cf9aefb0e0e258c55f528eb6d64) | `` stalwart_0_16: 0.16.14 -> 0.16.15 ``                                                                           |
| [`84687b1d`](https://github.com/NixOS/nixpkgs/commit/84687b1db3e82f11fe4ddbd469708fd091ec629f) | `` stalwart_0_16.webui: 1.0.4 -> 1.0.6 ``                                                                         |
| [`0cdf113f`](https://github.com/NixOS/nixpkgs/commit/0cdf113f3812ceb75712bc891132f2a88fb96c9f) | `` stalwart_0_16.spam-filter: simplify build ``                                                                   |
| [`208daf9c`](https://github.com/NixOS/nixpkgs/commit/208daf9c9375729b9451f0e58b2ff07895cf813a) | `` python3Packages.dm-haiku: enable __structuredAttrs ``                                                          |
| [`58923c39`](https://github.com/NixOS/nixpkgs/commit/58923c39f4df03def9a68709d9510a3bba6eff27) | `` python3Packages.dm-haiku: use finalAttrs ``                                                                    |
| [`dc1391b6`](https://github.com/NixOS/nixpkgs/commit/dc1391b694abc31139fba48c0ef9ae8957791915) | `` bleachbit: 6.0.0 -> 6.0.2 ``                                                                                   |
| [`ab074c3a`](https://github.com/NixOS/nixpkgs/commit/ab074c3a328353c971a6c7685570b0e3db516b0d) | `` repath-studio: add python to runtime closure ``                                                                |
| [`87deac41`](https://github.com/NixOS/nixpkgs/commit/87deac41f7810d56d2e65327d73d65e0fd40e98d) | `` repath-studio: fix update script ``                                                                            |
| [`f0848dbc`](https://github.com/NixOS/nixpkgs/commit/f0848dbc691a64cbcbfa6dfb5e945563312e460d) | `` repath-studio: fix darwin build ``                                                                             |
| [`cecdbd89`](https://github.com/NixOS/nixpkgs/commit/cecdbd892c164757db17299cd280ebd291df422f) | `` python3Packages.pymc: 6.1.0 -> 6.2.0 ``                                                                        |
| [`48081132`](https://github.com/NixOS/nixpkgs/commit/48081132f50bb8948ab4fa25663fa5469cf9a6e1) | `` ocamlPackages.frama-c-lannotate: 0.2.5 -> 0.2.6 ``                                                             |
| [`d489a86d`](https://github.com/NixOS/nixpkgs/commit/d489a86df8332dc751fa216f774025e2fe920e8f) | `` ocamlPackages.frama-c-luncov: 0.2.4-unstable-2025-11-24 -> 0.2.6 ``                                            |
| [`d2f132db`](https://github.com/NixOS/nixpkgs/commit/d2f132db75ca55fc2c55ba93704dac6cec1b96c5) | `` frama-c-gui: rename from ivette, 32.1 -> 33.0 ``                                                               |
| [`3d0f19c3`](https://github.com/NixOS/nixpkgs/commit/3d0f19c39e8439469b3478eb4937d4fd8b20d052) | `` python3Packages.pytensor: 3.1.3 -> 3.2.3 ``                                                                    |
| [`7bdce7a4`](https://github.com/NixOS/nixpkgs/commit/7bdce7a42b218a21912de82fdb05b7a681fe0ff9) | `` python3Packages.pytensor: relax numba ``                                                                       |
| [`fe3d616b`](https://github.com/NixOS/nixpkgs/commit/fe3d616b77f25956120da77fa3a51f4da5079884) | `` ocamlPackages.crunch: 4.0.0 → 4.1.0 ``                                                                         |
| [`6706b3d5`](https://github.com/NixOS/nixpkgs/commit/6706b3d5aa57c3a0afadd50c5a6b2f4ffa0dfe72) | `` maintainers: add staticdev to nextcloud team ``                                                                |
| [`7502d883`](https://github.com/NixOS/nixpkgs/commit/7502d88324158b4442d9a1eaf52d0a72b1e3f9f4) | `` nextcloudPackages: update ``                                                                                   |
| [`3a19dc2e`](https://github.com/NixOS/nixpkgs/commit/3a19dc2e7706156cd1452bb644444866521844fc) | `` argocd-vault-plugin: modernize ``                                                                              |
| [`7134f783`](https://github.com/NixOS/nixpkgs/commit/7134f7833162492b54ded68294b7305fad28ca65) | `` snip: 0.22.0 -> 0.24.1 ``                                                                                      |
| [`0e49ad90`](https://github.com/NixOS/nixpkgs/commit/0e49ad90f4ac557124cc6677c19166ffff9c2565) | `` nixos/version: Handle the other attributes ``                                                                  |
| [`96b71349`](https://github.com/NixOS/nixpkgs/commit/96b713497e4bde6490fae1ebc253c4ea3e5bcdec) | `` nixos/version: Add an optionalAttr function ``                                                                 |
| [`c9797b4c`](https://github.com/NixOS/nixpkgs/commit/c9797b4c58dea15ebd2a63e794166c89738402f5) | `` repath-studio: 0.4.16 -> 0.4.18 ``                                                                             |
| [`08e0e1b6`](https://github.com/NixOS/nixpkgs/commit/08e0e1b6673c68e7419072c034273af3bf60fbe9) | `` nixos/nspawn-container: remove outdated comment and flush ``                                                   |
| [`99a0153c`](https://github.com/NixOS/nixpkgs/commit/99a0153c8e3ff3d0a18d686ad6a3491e22b7e1c8) | `` edit: fix version ``                                                                                           |
| [`8527eb4c`](https://github.com/NixOS/nixpkgs/commit/8527eb4cce1ae4f1a6a40e45eb3ad299e7cfb95b) | `` python3Packages.jupyterlab-git-core: init at 0.54.0 ``                                                         |
| [`693e3bc4`](https://github.com/NixOS/nixpkgs/commit/693e3bc4155787b03d2e36523b43da32b268305c) | `` nixos/systemd: patch to avoid update-utmp failure with audit 4.2 ``                                            |
| [`7a33dd08`](https://github.com/NixOS/nixpkgs/commit/7a33dd082ee412cf55d1a3bf80e75d088447258a) | `` Revert "python3Packages.systemd-python: switch to systemdLibs" ``                                              |
| [`dd5dce68`](https://github.com/NixOS/nixpkgs/commit/dd5dce68bec46c6e3b14cf11d0e03fc7b8b5a547) | `` ty: 0.0.64 -> 0.0.65 ``                                                                                        |
| [`f7cffb8f`](https://github.com/NixOS/nixpkgs/commit/f7cffb8ff3a82cb39cd360a3f21137f6144abe94) | `` nixos-rebuild-ng: remove old comment and unnecessary cast ``                                                   |
| [`4e34283c`](https://github.com/NixOS/nixpkgs/commit/4e34283c2ebaf906175a08b8595bd82881940d1b) | `` gcc13: fix build with linux 7.1 headers ``                                                                     |
| [`f9ebb12b`](https://github.com/NixOS/nixpkgs/commit/f9ebb12ba5b065834901a50493e5ff462e5d4da8) | `` nodejs_24: 24.18.0 -> 24.18.1 ``                                                                               |
| [`3d1ce5f5`](https://github.com/NixOS/nixpkgs/commit/3d1ce5f5e071ed96f5a969197f81e4b514cfa903) | `` vimPlugins.hermes-nvim: init at 0.12.1 ``                                                                      |
| [`39c9101c`](https://github.com/NixOS/nixpkgs/commit/39c9101c3a0bc4c590308f4a1f8d85a89348a571) | `` nixos-rebuild-ng: fix ruff linter warns ``                                                                     |
| [`671abf41`](https://github.com/NixOS/nixpkgs/commit/671abf4122e5a38e225959cb8717e226ab1cb56d) | `` mariadb-connector-java: 3.5.7 -> 3.5.10 ``                                                                     |
| [`0917eb9b`](https://github.com/NixOS/nixpkgs/commit/0917eb9b09edc3c09dedaf0e15a302e61c971568) | `` jx: 3.17.17 -> 3.17.61 ``                                                                                      |
| [`f914a7e3`](https://github.com/NixOS/nixpkgs/commit/f914a7e33e5c471eae1382b53bf2acf70c23b71d) | `` nixos-rebuild-ng: flake_resolved -> flake_path ``                                                              |
| [`83a89abe`](https://github.com/NixOS/nixpkgs/commit/83a89abeef7b94f0f6847e4c7ef6dd3933755cef) | `` nixos-rebuild-ng: flake repl: resolve flake url with `nix flake metadata` ``                                   |
| [`55b567da`](https://github.com/NixOS/nixpkgs/commit/55b567dafd9dea48142efbbcc58e3913ab206ab3) | `` frama-c: 32.1 -> 33.0 ``                                                                                       |
| [`a372f6f4`](https://github.com/NixOS/nixpkgs/commit/a372f6f4211d1aa1c7d02422c150e32427dc8765) | `` angrr: 0.2.6 -> 0.2.7 ``                                                                                       |
| [`28d06047`](https://github.com/NixOS/nixpkgs/commit/28d060472fec4ca7ecda2bd72bc610aa8c096812) | `` solarus: 2.0.4 -> 2.1.0 ``                                                                                     |
| [`85a7c427`](https://github.com/NixOS/nixpkgs/commit/85a7c427304f92ae549192d17e069e4e5bebbec2) | `` net-snmp: import Debian patch to fix link error ``                                                             |
| [`d74c85af`](https://github.com/NixOS/nixpkgs/commit/d74c85afc565e0c996dc316f0a6bd8c81ede58d2) | `` python3Packages.tinyrecord: modernize ``                                                                       |
| [`2d7609ba`](https://github.com/NixOS/nixpkgs/commit/2d7609ba26fd8cac9310d55a4ae2c88a559ab832) | `` python3Packages.tinyrecord: migrate to pyproject ``                                                            |
| [`40d50288`](https://github.com/NixOS/nixpkgs/commit/40d5028867a928087a2aff6269e48c9de16c6ba7) | `` python3Packages.temperusb: enable tests ``                                                                     |
| [`27fe417d`](https://github.com/NixOS/nixpkgs/commit/27fe417d5eaf2cb30aa796db0cf654eeec5208b7) | `` python3Packages.temperusb: migrate to pyproject ``                                                             |
| [`fea0fb66`](https://github.com/NixOS/nixpkgs/commit/fea0fb660bf2029c6ca748bfc9ffd3520423ba7d) | `` warpgate: cleanup ``                                                                                           |
| [`5c396572`](https://github.com/NixOS/nixpkgs/commit/5c39657284dc5ca5c38ab8504a98cddf6998b3e6) | `` warpgate: add changelog ``                                                                                     |
| [`2bf96755`](https://github.com/NixOS/nixpkgs/commit/2bf96755ad2b847656b84002b560b6577501c52a) | `` warpgate: 0.23.4 -> 0.26.1 ``                                                                                  |
| [`9bd53b9b`](https://github.com/NixOS/nixpkgs/commit/9bd53b9b2cfa61d641af07671053c1ade78de4f8) | `` warpgate: add updateScript ``                                                                                  |
| [`08eac1bc`](https://github.com/NixOS/nixpkgs/commit/08eac1bc2b2380bf853f38a4fb45c856717d7c38) | `` gerrit: Enable strictDeps and structuredAttrs ``                                                               |
| [`711a0ca6`](https://github.com/NixOS/nixpkgs/commit/711a0ca6ceab63e69233d7f79429d82d988ff191) | `` gerrit_3_13: init at 3.13.8 ``                                                                                 |
| [`f39398d1`](https://github.com/NixOS/nixpkgs/commit/f39398d120d054a0b378f542950f06f09e9c9823) | `` gerrit_3_12: init at 3.12.9 ``                                                                                 |
| [`3bccf219`](https://github.com/NixOS/nixpkgs/commit/3bccf21969d56534666c6a9e5d4672be0617a8f7) | `` gerrit: Make package definition generic ``                                                                     |
| [`3b2ec62f`](https://github.com/NixOS/nixpkgs/commit/3b2ec62f1876a7aec8e70d29c8e4fa5378f4051d) | `` gerrit: Replace gitUpdater with nix-update-script ``                                                           |
| [`d67db591`](https://github.com/NixOS/nixpkgs/commit/d67db5916d9e43df5814cf00f2be6ce67aee9cd7) | `` open-webui: remove ffmpeg-headless from frontend propagatedBuildInputs ``                                      |
| [`0e691ca3`](https://github.com/NixOS/nixpkgs/commit/0e691ca3e8f4e645f435f7ad3ad22cf58da3c5da) | `` python3Packages.pydub: don't warn on calls to ffmpeg ``                                                        |
| [`1e7da208`](https://github.com/NixOS/nixpkgs/commit/1e7da20850ed70eb5d326bbfce17cef95b7a67b2) | `` gromacs: select more specific SIMD instruction sets ``                                                         |
| [`4ebeaf66`](https://github.com/NixOS/nixpkgs/commit/4ebeaf6692524bace3402633f9d7a1b88848c349) | `` cosmic-comp: libdisplay-info_0_2 -> libdisplay-info_0_3 ``                                                     |
| [`92453f26`](https://github.com/NixOS/nixpkgs/commit/92453f265c5016405b5f1775a99b0e16934bee10) | `` linux: enable BSD_DISKLABEL ``                                                                                 |
| [`f0d1f25a`](https://github.com/NixOS/nixpkgs/commit/f0d1f25a84f76c140c75a23af7babcd998dddb03) | `` quartz-wm: switch to upstream build fix ``                                                                     |
| [`5a4c71fa`](https://github.com/NixOS/nixpkgs/commit/5a4c71fa7d9dc5d1f1982a5717718832f1f9d84b) | `` gitify: 6.20.0 -> 7.0.1 ``                                                                                     |
| [`62532f36`](https://github.com/NixOS/nixpkgs/commit/62532f365c0124f4eb8f5c8dc3271a26b1c4db17) | `` nerva: 1.48.1 -> 1.53.1 ``                                                                                     |
| [`3d6a4d6b`](https://github.com/NixOS/nixpkgs/commit/3d6a4d6b5e39738d243e9c29a56c289c0e553225) | `` ty: 0.0.63 -> 0.0.64 ``                                                                                        |
| [`761e0ece`](https://github.com/NixOS/nixpkgs/commit/761e0ecefb74895fb72f55b1efc4388eb2a03b3c) | `` python3Packages.pyturbojpeg: 2.4.0 -> 2.5.0 ``                                                                 |
| [`faf17b1a`](https://github.com/NixOS/nixpkgs/commit/faf17b1ac0e1b5592dabdacb333201f252688b14) | `` imagemagick: 7.1.2-28 -> 7.1.2-29 ``                                                                           |
| [`2b69f6ae`](https://github.com/NixOS/nixpkgs/commit/2b69f6aeae024b6f48dc3f92fb57b35a92160745) | `` halloy: 2026.7.2 -> 2026.8 ``                                                                                  |
| [`2cd30188`](https://github.com/NixOS/nixpkgs/commit/2cd3018868fd4766b709b5b65c1c18adbf06076d) | `` python3Packages.datamodel-code-generator: 0.68.1 -> 0.71.0 ``                                                  |
| [`e41cfdd1`](https://github.com/NixOS/nixpkgs/commit/e41cfdd1e20dd052946542ca0259e2e987601438) | `` lakefs: 1.83.0 -> 1.84.1 ``                                                                                    |
| [`6432c4c6`](https://github.com/NixOS/nixpkgs/commit/6432c4c6cc163a4bb8d8b314c01ccaef2133ff93) | `` python3Packages.libcap_ng: init at 0.9.3 ``                                                                    |
| [`a7bd1086`](https://github.com/NixOS/nixpkgs/commit/a7bd1086d028c0523e9eddb22c26331538162fc8) | `` libcap_ng: support building python bindings ``                                                                 |
| [`6b15470f`](https://github.com/NixOS/nixpkgs/commit/6b15470f3c7de5ff88a4ef68a3e44926b27ee2c1) | `` libcap_ng: enable structuredAttrs ``                                                                           |
| [`43ef5cad`](https://github.com/NixOS/nixpkgs/commit/43ef5cad7eae326948335de3667e7c86ac301622) | `` nezha-agent: 2.2.3 -> 2.3.0 ``                                                                                 |
| [`465aa744`](https://github.com/NixOS/nixpkgs/commit/465aa74425d28f11bcc285a0c45d078c38331639) | `` imagemagick: 7.1.2-27 -> 7.1.2-28 ``                                                                           |
| [`d5b6cbf9`](https://github.com/NixOS/nixpkgs/commit/d5b6cbf90ba4855f853151482127eea8b9cfa3c8) | `` llvmPackages_{18,19,20,21}.compiler-rt: backport santizier fix for Linux ``                                    |
| [`8d721cd4`](https://github.com/NixOS/nixpkgs/commit/8d721cd4327e1835f42d35b0a4f0cb97a296b924) | `` linux: add MODULE_DECOMPRESS to common-config.nix ``                                                           |
| [`ef43fffd`](https://github.com/NixOS/nixpkgs/commit/ef43fffdb0dab491f9e93345bdbd2a4a8477100d) | `` maintainers: add ruddickmg ``                                                                                  |
| [`2349def7`](https://github.com/NixOS/nixpkgs/commit/2349def73196e4c2470a5866df3e6907a06a568f) | `` catch2_3: 3.15.2 -> 3.15.3 ``                                                                                  |
| [`b8172d3d`](https://github.com/NixOS/nixpkgs/commit/b8172d3d689b6de60810f3b16bb3f1f8985be487) | `` async-profiler: 4.3 -> 4.5 ``                                                                                  |
| [`f1d2364e`](https://github.com/NixOS/nixpkgs/commit/f1d2364ed16930b2357729ab8e2c898c7eee0652) | `` coreutils: security patches ``                                                                                 |
| [`67073b57`](https://github.com/NixOS/nixpkgs/commit/67073b57ac26a416b100adaf17fde2a412da9d8f) | `` python3Packages.anyio: Disable test_keyboard_interrupt_does_not_resume_test ``                                 |
| [`c249d818`](https://github.com/NixOS/nixpkgs/commit/c249d818530c629aa1bb63d047cd64eed32002e9) | `` usrsctp: make unused-but-set-variable non-fatal for gcc 16 ``                                                  |
| [`ae10855c`](https://github.com/NixOS/nixpkgs/commit/ae10855cc4be0b15416a6f4843a068c66a9512e4) | `` python3Packages.itables: 2.8.1 -> 2.9.1 ``                                                                     |
| [`5b465523`](https://github.com/NixOS/nixpkgs/commit/5b4655232a2e74c8fa2b8f44a86eac11fa8336ba) | `` python3Packages.pytest-examples: fix build w/ latest ruff ``                                                   |
| [`792c2d51`](https://github.com/NixOS/nixpkgs/commit/792c2d51773fb286d58feaebc5c97c55bbfeecaf) | `` socalabs-voc: 1.1.5 -> 1.1.7 ``                                                                                |
| [`18bbd751`](https://github.com/NixOS/nixpkgs/commit/18bbd751b0403d7b60adc8380762986d3cc268df) | `` socalabs-sn76489: 1.1.5 -> 1.1.7 ``                                                                            |
| [`ccdca65d`](https://github.com/NixOS/nixpkgs/commit/ccdca65d82a0120bba72a5512eb1dbe069f73c7e) | `` bcachefs-tools: Fetch patch to fix compile-time assertion failure on big-endian ``                             |
| [`503d4617`](https://github.com/NixOS/nixpkgs/commit/503d46170d6fa1e9dd510c5cc339323055e05e50) | `` nixos/nspawn-container: fix build ``                                                                           |
| [`742a1495`](https://github.com/NixOS/nixpkgs/commit/742a14957d35ad0026fab4e749be1a86f757512e) | `` opn2bankeditor: 1.3-unstable-2026-05-05 -> 1.3-unstable-2026-07-24 ``                                          |
| [`28466c8f`](https://github.com/NixOS/nixpkgs/commit/28466c8f2766f1fb415ef12df34c9ef207e2cdb1) | `` opl3bankeditor: 1.5.1-unstable-2026-06-06 -> 1.5.1-unstable-2026-07-24 ``                                      |
| [`990ad6d2`](https://github.com/NixOS/nixpkgs/commit/990ad6d2d39bf9b35c19ea9224037927677e4b22) | `` libresidfp: 1.1.1 -> 1.1.2 ``                                                                                  |
| [`44d362d5`](https://github.com/NixOS/nixpkgs/commit/44d362d5a61e4a7aa5dbbf2c06262ff335beba80) | `` linuxHeaders: 7.0 -> 7.1 ``                                                                                    |
| [`aa7a3b1c`](https://github.com/NixOS/nixpkgs/commit/aa7a3b1c68b1992f1541d950a5b9490af73b327d) | `` javaPackages.compiler.openjdk21: 21.0.12+2 -> 21.0.12+8 ``                                                     |
| [`d8f639ff`](https://github.com/NixOS/nixpkgs/commit/d8f639ff89d9b709c1d2925955ccd0593ec9b7db) | `` s2n-tls: 1.7.2 -> 1.7.6 ``                                                                                     |

*... and 98 more commits (truncated)*